### PR TITLE
Add universal header with profile/logout buttons

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,13 +1,41 @@
-import React, { useState } from 'react';
-import { View, TouchableOpacity, StyleSheet, Modal, Text } from 'react-native';
+import React, { useState, useRef } from 'react';
+import {
+  View,
+  TouchableOpacity,
+  StyleSheet,
+  Modal,
+  Text,
+  Animated,
+  Dimensions,
+  TouchableWithoutFeedback,
+} from 'react-native';
 import { Feather } from '@expo/vector-icons';
 
 export default function Header({ navigation }) {
   const [profileVisible, setProfileVisible] = useState(false);
+  const slideAnim = useRef(new Animated.Value(-Dimensions.get('window').width / 2)).current;
+
+  const openProfile = () => {
+    setProfileVisible(true);
+    Animated.timing(slideAnim, {
+      toValue: 0,
+      duration: 300,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  const closeProfile = () => {
+    Animated.timing(slideAnim, {
+      toValue: -Dimensions.get('window').width / 2,
+      duration: 300,
+      useNativeDriver: true,
+    }).start(() => setProfileVisible(false));
+  };
+
   return (
     <>
       <View style={styles.headerTop}>
-        <TouchableOpacity onPress={() => setProfileVisible(true)}>
+        <TouchableOpacity onPress={openProfile}>
           <Feather name="user" size={22} color="#A57C36" />
         </TouchableOpacity>
         <TouchableOpacity onPress={() => navigation.replace('Login')}>
@@ -16,18 +44,23 @@ export default function Header({ navigation }) {
       </View>
       <Modal
         visible={profileVisible}
-        animationType="slide"
-        onRequestClose={() => setProfileVisible(false)}
+        transparent
+        animationType="none"
+        onRequestClose={closeProfile}
       >
-        <View style={styles.modalContainer}>
-          <TouchableOpacity
-            style={styles.closeIcon}
-            onPress={() => setProfileVisible(false)}
+        <View style={styles.overlayContainer}>
+          <TouchableWithoutFeedback onPress={closeProfile}>
+            <View style={styles.overlay} />
+          </TouchableWithoutFeedback>
+          <Animated.View
+            style={[styles.modalContainer, { transform: [{ translateX: slideAnim }] }]}
           >
-            <Feather name="x" size={24} color="#A57C36" />
-          </TouchableOpacity>
-          <Text style={styles.modalTitle}>Perfil del Usuario</Text>
-          {/* Aquí iría la info del usuario */}
+            <TouchableOpacity style={styles.closeIcon} onPress={closeProfile}>
+              <Feather name="x" size={24} color="#A57C36" />
+            </TouchableOpacity>
+            <Text style={styles.modalTitle}>Perfil del Usuario</Text>
+            {/* Aquí iría la info del usuario */}
+          </Animated.View>
         </View>
       </Modal>
     </>
@@ -43,7 +76,11 @@ const styles = StyleSheet.create({
     paddingBottom: 10,
   },
   modalContainer: {
-    flex: 1,
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    width: Dimensions.get('window').width / 2,
     paddingTop: 60,
     paddingHorizontal: 20,
     backgroundColor: '#FBFAF7',
@@ -57,5 +94,12 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     textAlign: 'center',
     color: '#1F1F1F',
+  },
+  overlayContainer: {
+    flex: 1,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.3)',
   },
 });

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,17 +1,36 @@
-import React from 'react';
-import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { View, TouchableOpacity, StyleSheet, Modal, Text } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 
 export default function Header({ navigation }) {
+  const [profileVisible, setProfileVisible] = useState(false);
   return (
-    <View style={styles.headerTop}>
-      <TouchableOpacity onPress={() => navigation.navigate('Perfil')}>
-        <Feather name="user" size={22} color="#A57C36" />
-      </TouchableOpacity>
-      <TouchableOpacity onPress={() => navigation.replace('Login')}>
-        <Feather name="log-out" size={22} color="#c0392b" />
-      </TouchableOpacity>
-    </View>
+    <>
+      <View style={styles.headerTop}>
+        <TouchableOpacity onPress={() => setProfileVisible(true)}>
+          <Feather name="user" size={22} color="#A57C36" />
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => navigation.replace('Login')}>
+          <Feather name="log-out" size={22} color="#c0392b" />
+        </TouchableOpacity>
+      </View>
+      <Modal
+        visible={profileVisible}
+        animationType="slide"
+        onRequestClose={() => setProfileVisible(false)}
+      >
+        <View style={styles.modalContainer}>
+          <TouchableOpacity
+            style={styles.closeIcon}
+            onPress={() => setProfileVisible(false)}
+          >
+            <Feather name="x" size={24} color="#A57C36" />
+          </TouchableOpacity>
+          <Text style={styles.modalTitle}>Perfil del Usuario</Text>
+          {/* Aquí iría la info del usuario */}
+        </View>
+      </Modal>
+    </>
   );
 }
 
@@ -22,5 +41,21 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: 12,
     paddingBottom: 10,
+  },
+  modalContainer: {
+    flex: 1,
+    paddingTop: 60,
+    paddingHorizontal: 20,
+    backgroundColor: '#FBFAF7',
+  },
+  closeIcon: {
+    alignSelf: 'flex-end',
+    marginBottom: 10,
+  },
+  modalTitle: {
+    fontSize: 24,
+    fontWeight: '700',
+    textAlign: 'center',
+    color: '#1F1F1F',
   },
 });

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+export default function Header({ navigation }) {
+  return (
+    <View style={styles.headerTop}>
+      <TouchableOpacity onPress={() => navigation.navigate('Perfil')}>
+        <Feather name="user" size={22} color="#A57C36" />
+      </TouchableOpacity>
+      <TouchableOpacity onPress={() => navigation.replace('Login')}>
+        <Feather name="log-out" size={22} color="#c0392b" />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerTop: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingBottom: 10,
+  },
+});

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { MaterialCommunityIcons, Feather } from '@expo/vector-icons';
+
+export default function NavBar({ navigation, active }) {
+  return (
+    <View style={styles.navContainer}>
+      <TouchableOpacity
+        style={styles.navItem}
+        onPress={() => navigation.navigate('Dashboard')}
+      >
+        <MaterialCommunityIcons
+          name="speedometer"
+          size={20}
+          color={active === 'Dashboard' ? '#000' : '#A57C36'}
+        />
+        <Text style={[styles.navText, active === 'Dashboard' && styles.navActive]}>Dashboard</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={styles.navItem}
+        onPress={() => navigation.navigate('Transaccion')}
+      >
+        <Feather
+          name="menu"
+          size={20}
+          color={active === 'Transaccion' ? '#000' : '#A57C36'}
+        />
+        <Text style={[styles.navText, active === 'Transaccion' && styles.navActive]}>Transacciones</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={styles.navItem}
+        onPress={() => navigation.navigate('Finanzas')}
+      >
+        <Feather
+          name="trending-up"
+          size={20}
+          color={active === 'Finanzas' ? '#000' : '#A57C36'}
+        />
+        <Text style={[styles.navText, active === 'Finanzas' && styles.navActive]}>Finanzas</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={styles.navItem}
+        onPress={() => navigation.navigate('Presupuesto')}
+      >
+        <MaterialCommunityIcons
+          name="scale-balance"
+          size={20}
+          color={active === 'Presupuesto' ? '#000' : '#A57C36'}
+        />
+        <Text style={[styles.navText, active === 'Presupuesto' && styles.navActive]}>Presupuestos</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  navContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+    marginBottom: 20,
+    backgroundColor: '#FDFBF6',
+  },
+  navItem: {
+    minWidth: 80,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+  },
+  navText: {
+    fontSize: 13,
+    color: '#A57C36',
+    marginTop: 4,
+    textAlign: 'center',
+  },
+  navActive: {
+    fontWeight: 'bold',
+    color: '#000',
+  },
+});

--- a/src/screens/DashboardScreen.js
+++ b/src/screens/DashboardScreen.js
@@ -8,6 +8,7 @@ import {
   Dimensions,
 } from 'react-native';
 import { MaterialCommunityIcons, Feather } from '@expo/vector-icons';
+import Header from '../components/Header';
 
 const screenWidth = Dimensions.get('window').width;
 
@@ -27,14 +28,7 @@ export default function DashboardScreen({ navigation }) {
   return (
     <ScrollView style={styles.container}>
       {/* HEADER CON PERFIL Y LOGOUT */}
-      <View style={styles.headerTop}>
-        <TouchableOpacity onPress={() => navigation.navigate('Perfil')}>
-          <Feather name="user" size={22} color="#A57C36" />
-        </TouchableOpacity>
-        <TouchableOpacity onPress={() => navigation.replace('Login')}>
-          <Feather name="log-out" size={22} color="#c0392b" />
-        </TouchableOpacity>
-      </View>
+      <Header navigation={navigation} />
 
       {/* NAV BAR SUPERIOR */}
       <View style={styles.navContainer}>
@@ -107,13 +101,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#FBFAF7',
     paddingTop: 40,
     paddingHorizontal: 16,
-  },
-  headerTop: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingHorizontal: 12,
-    paddingBottom: 10,
   },
   navContainer: {
     flexDirection: 'row',

--- a/src/screens/DashboardScreen.js
+++ b/src/screens/DashboardScreen.js
@@ -4,11 +4,10 @@ import {
   Text,
   StyleSheet,
   ScrollView,
-  TouchableOpacity,
   Dimensions,
 } from 'react-native';
-import { MaterialCommunityIcons, Feather } from '@expo/vector-icons';
 import Header from '../components/Header';
+import NavBar from '../components/NavBar';
 
 const screenWidth = Dimensions.get('window').width;
 
@@ -31,27 +30,7 @@ export default function DashboardScreen({ navigation }) {
       <Header navigation={navigation} />
 
       {/* NAV BAR SUPERIOR */}
-      <View style={styles.navContainer}>
-        <TouchableOpacity style={styles.navItem}>
-          <MaterialCommunityIcons name="speedometer" size={20} color="#000" />
-          <Text style={[styles.navText, styles.navActive]}>Dashboard</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Transaccion')}>
-          <Feather name="menu" size={20} color="#A57C36" />
-          <Text style={styles.navText}>Transacciones</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Finanzas')}>
-          <Feather name="trending-up" size={20} color="#A57C36" />
-          <Text style={styles.navText}>Finanzas</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Presupuesto')}>
-          <MaterialCommunityIcons name="scale-balance" size={20} color="#A57C36" />
-          <Text style={styles.navText}>Presupuestos</Text>
-        </TouchableOpacity>
-      </View>
+      <NavBar navigation={navigation} active="Dashboard" />
 
       {/* TITULO */}
       <Text style={styles.title}>Resumen Financiero</Text>
@@ -101,33 +80,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#FBFAF7',
     paddingTop: 40,
     paddingHorizontal: 16,
-  },
-  navContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: '#eee',
-    marginBottom: 20,
-    backgroundColor: '#FDFBF6',
-  },
-  navItem: {
-    minWidth: 80,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 4,
-  },
-  navText: {
-    fontSize: 13,
-    color: '#A57C36',
-    marginTop: 4,
-    textAlign: 'center',
-  },
-  navActive: {
-    fontWeight: 'bold',
-    color: '#000',
   },
   title: {
     fontSize: 24,

--- a/src/screens/FinanzasScreen.js
+++ b/src/screens/FinanzasScreen.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions } from 'react-native';
 import { Ionicons, MaterialCommunityIcons, Feather } from '@expo/vector-icons';
+import Header from '../components/Header';
 
 const screenWidth = Dimensions.get('window').width;
 
@@ -16,6 +17,7 @@ export default function FinanzasScreen({ navigation }) {
 
   return (
     <ScrollView style={styles.container}>
+      <Header navigation={navigation} />
       {/* NAV BAR SUPERIOR */}
       <View style={styles.navContainer}>
         <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Dashboard')}>

--- a/src/screens/FinanzasScreen.js
+++ b/src/screens/FinanzasScreen.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions } from 'react-native';
-import { Ionicons, MaterialCommunityIcons, Feather } from '@expo/vector-icons';
+import { View, Text, StyleSheet, ScrollView, Dimensions } from 'react-native';
 import Header from '../components/Header';
+import NavBar from '../components/NavBar';
 
 const screenWidth = Dimensions.get('window').width;
 
@@ -19,27 +19,7 @@ export default function FinanzasScreen({ navigation }) {
     <ScrollView style={styles.container}>
       <Header navigation={navigation} />
       {/* NAV BAR SUPERIOR */}
-      <View style={styles.navContainer}>
-        <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Dashboard')}>
-          <MaterialCommunityIcons name="speedometer" size={20} color="#A57C36" />
-          <Text style={styles.navText}>Dashboard</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Transaccion')}>
-          <Feather name="menu" size={20} color="#A57C36" />
-          <Text style={styles.navText}>Transacciones</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.navItem}>
-          <Feather name="trending-up" size={20} color="#000" />
-          <Text style={[styles.navText, styles.navActive]}>Finanzas</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Presupuesto')}>
-          <MaterialCommunityIcons name="scale-balance" size={20} color="#A57C36" />
-          <Text style={styles.navText}>Presupuestos</Text>
-        </TouchableOpacity>
-      </View>
+      <NavBar navigation={navigation} active="Finanzas" />
 
       {/* TITULO */}
       <Text style={styles.title}>Estado Financiero</Text>
@@ -84,32 +64,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#FBFAF7',
     paddingTop: 40,
     paddingHorizontal: 16,
-  },
-  navContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    alignItems: 'center',
-    paddingBottom: 14,
-    borderBottomWidth: 1,
-    borderBottomColor: '#eee',
-    marginBottom: 20,
-    flexWrap: 'wrap',
-  },
-  navItem: {
-  minWidth: 80, // o 90 si aún no cabe
-  alignItems: 'center',
-  justifyContent: 'center',
-  paddingHorizontal: 4,
-},
-  navText: {
-    fontSize: 13,
-    color: '#A57C36',
-    marginTop: 4,
-    textAlign: 'center',
-  },
-  navActive: {
-    fontWeight: 'bold',
-    color: '#000',
   },
   title: {
     fontSize: 24,

--- a/src/screens/PerfilScreen.js
+++ b/src/screens/PerfilScreen.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import Header from '../components/Header';
 
-export default function PerfilScreen() {
+export default function PerfilScreen({ navigation }) {
   return (
     <View style={styles.container}>
+      <Header navigation={navigation} />
       <Text style={styles.title}>Perfil del Usuario</Text>
       {/* Aquí iría la info del usuario */}
     </View>

--- a/src/screens/PresupuestosScreen.js
+++ b/src/screens/PresupuestosScreen.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
-import { MaterialCommunityIcons, Feather } from '@expo/vector-icons';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import Header from '../components/Header';
+import NavBar from '../components/NavBar';
 
 export default function PresupuestosScreen({ navigation }) {
   const [budgets, setBudgets] = useState([]);
@@ -29,27 +29,7 @@ export default function PresupuestosScreen({ navigation }) {
     <ScrollView style={styles.container}>
       <Header navigation={navigation} />
       {/* NAV BAR SUPERIOR */}
-      <View style={styles.navContainer}>
-        <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Dashboard')}>
-          <MaterialCommunityIcons name="speedometer" size={20} color="#A57C36" />
-          <Text style={styles.navText}>Dashboard</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Transaccion')}>
-          <Feather name="menu" size={20} color="#A57C36" />
-          <Text style={styles.navText}>Transacciones</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Finanzas')}>
-          <Feather name="trending-up" size={20} color="#A57C36" />
-          <Text style={styles.navText}>Finanzas</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.navItem}>
-          <MaterialCommunityIcons name="scale-balance" size={20} color="#000" />
-          <Text style={[styles.navText, styles.navActive]}>Presupuestos</Text>
-        </TouchableOpacity>
-      </View>
+      <NavBar navigation={navigation} active="Presupuesto" />
 
       <Text style={styles.title}>Mis Presupuestos</Text>
 
@@ -78,33 +58,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#FBFAF7',
     paddingTop: 40,
     paddingHorizontal: 16,
-  },
-  navContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: '#eee',
-    marginBottom: 20,
-    backgroundColor: '#FDFBF6',
-  },
-  navItem: {
-  minWidth: 80, // o 90 si aún no cabe
-  alignItems: 'center',
-  justifyContent: 'center',
-  paddingHorizontal: 4,
-},
-  navText: {
-    fontSize: 13,
-    color: '#A57C36',
-    marginTop: 4,
-    textAlign: 'center',
-  },
-  navActive: {
-    fontWeight: 'bold',
-    color: '#000',
   },
   title: {
     fontSize: 24,

--- a/src/screens/PresupuestosScreen.js
+++ b/src/screens/PresupuestosScreen.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
 import { MaterialCommunityIcons, Feather } from '@expo/vector-icons';
+import Header from '../components/Header';
 
 export default function PresupuestosScreen({ navigation }) {
   const [budgets, setBudgets] = useState([]);
@@ -26,6 +27,7 @@ export default function PresupuestosScreen({ navigation }) {
 
   return (
     <ScrollView style={styles.container}>
+      <Header navigation={navigation} />
       {/* NAV BAR SUPERIOR */}
       <View style={styles.navContainer}>
         <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Dashboard')}>

--- a/src/screens/TransaccionesScreen.js
+++ b/src/screens/TransaccionesScreen.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
-import { Feather, MaterialCommunityIcons } from '@expo/vector-icons';
 import Header from '../components/Header';
+import NavBar from '../components/NavBar';
 
 export default function TransaccionesScreen({ navigation }) {
   const transactions = [
@@ -15,27 +15,7 @@ export default function TransaccionesScreen({ navigation }) {
     <ScrollView style={styles.container}>
       <Header navigation={navigation} />
       {/* NAV BAR SUPERIOR */}
-      <View style={styles.navContainer}>
-        <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Dashboard')}>
-          <MaterialCommunityIcons name="speedometer" size={20} color="#A57C36" />
-          <Text style={styles.navText}>Dashboard</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.navItem}>
-          <Feather name="menu" size={20} color="#000" />
-          <Text style={[styles.navText, styles.navActive]}>Transacciones</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Finanzas')}>
-          <Feather name="trending-up" size={20} color="#A57C36" />
-          <Text style={styles.navText}>Finanzas</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Presupuesto')}>
-          <MaterialCommunityIcons name="scale-balance" size={20} color="#A57C36" />
-          <Text style={styles.navText}>Presupuestos</Text>
-        </TouchableOpacity>
-      </View>
+      <NavBar navigation={navigation} active="Transaccion" />
 
       {/* TÍTULO */}
       <Text style={styles.title}>Transacciones - Enero 2025</Text>
@@ -94,33 +74,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#FBFAF7',
     paddingTop: 40,
     paddingHorizontal: 16,
-  },
-  navContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: '#eee',
-    marginBottom: 20,
-    backgroundColor: '#FDFBF6',
-  },
-  navItem: {
-  minWidth: 80, // o 90 si aún no cabe
-  alignItems: 'center',
-  justifyContent: 'center',
-  paddingHorizontal: 4,
-},
-  navText: {
-    fontSize: 13,
-    color: '#A57C36',
-    marginTop: 4,
-    textAlign: 'center',
-  },
-  navActive: {
-    fontWeight: 'bold',
-    color: '#000',
   },
   title: {
     fontSize: 24,

--- a/src/screens/TransaccionesScreen.js
+++ b/src/screens/TransaccionesScreen.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
 import { Feather, MaterialCommunityIcons } from '@expo/vector-icons';
+import Header from '../components/Header';
 
 export default function TransaccionesScreen({ navigation }) {
   const transactions = [
@@ -12,6 +13,7 @@ export default function TransaccionesScreen({ navigation }) {
 
   return (
     <ScrollView style={styles.container}>
+      <Header navigation={navigation} />
       {/* NAV BAR SUPERIOR */}
       <View style={styles.navContainer}>
         <TouchableOpacity style={styles.navItem} onPress={() => navigation.navigate('Dashboard')}>


### PR DESCRIPTION
## Summary
- add `Header` component displaying profile and logout icons
- use header component across dashboard, finances, budgets, transactions and profile screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876e86b2020832dac35716d9a83d2c3